### PR TITLE
mismatch training

### DIFF
--- a/train/gve_trainer.py
+++ b/train/gve_trainer.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.utils.rnn import pack_padded_sequence
 import numpy as np
+import random
 
 from .lrcn_trainer import LRCNTrainer
 
@@ -15,6 +16,7 @@ class GVETrainer(LRCNTrainer):
     def __init__(self, args, model, dataset, data_loader, logger, device, checkpoint=None):
         super().__init__(args, model, dataset, data_loader, logger, device, checkpoint)
         self.rl_lambda = args.loss_lambda
+        self.train_mismatch = args.train_mismatch
 
     def train_step(self, image_input, word_inputs, word_targets, lengths,
             labels):
@@ -22,11 +24,39 @@ class GVETrainer(LRCNTrainer):
         labels_onehot = self.model.convert_onehot(labels)
         labels_onehot = labels_onehot.to(self.device)
         self.model.zero_grad()
+
         outputs = self.model(image_input, word_inputs, lengths, labels,
                 labels_onehot=labels_onehot)
 
         # Reinforce loss
-        # Sample sentences
+        r_loss = self.calculate_reinforce_loss(image_input, labels, labels_onehot)
+
+        loss = self.rl_lambda * r_loss + self.criterion(outputs, word_targets)
+
+        alt_loss = self.train_mismatch
+        if alt_loss > 0:
+            alt_indices = self.get_alternate_indices(labels)
+            alt_image_input = image_input[alt_indices,:]
+            alt_outputs = self.model(alt_image_input, word_inputs,
+                lengths, labels, labels_onehot=labels_onehot)
+            alt_r_loss = self.calculate_reinforce_loss(alt_image_input, labels, labels_onehot)
+            alt_loss *= self.rl_lambda * alt_r_loss + self.criterion(alt_outputs, word_targets)
+
+        (loss - alt_loss).backward()
+        #nn.utils.clip_grad_norm(self.params, 10)
+        self.optimizer.step()
+
+        return loss
+
+    def get_alternate_indices(self, labels):
+        idx = []
+        for i in range(labels.shape[0]):
+            idx.append((random.choice((labels != labels[i]).nonzero())).item())
+        original_idx = list(range(labels.shape[0]))
+        # print("CONFLICT {}".format(np.sum(idx == original_idx)))
+        return idx
+
+    def calculate_reinforce_loss(self, image_input, labels, labels_onehot):
         sample_ids, log_ps, lengths = self.model.generate_sentence(image_input, self.start_word,
                 self.end_word, labels, labels_onehot=labels_onehot, max_sampling_length=50, sample=True)
         # Order sampled sentences/log_probabilities/labels by sentence length (required by LSTM)
@@ -44,9 +74,4 @@ class GVETrainer(LRCNTrainer):
         rewards = class_pred.gather(1, labels.view(-1,1)).squeeze()
         r_loss = -(log_ps.sum(dim=1) * rewards).sum()
 
-        loss = self.rl_lambda * r_loss/labels.size(0) + self.criterion(outputs, word_targets)
-        loss.backward()
-        #nn.utils.clip_grad_norm(self.params, 10)
-        self.optimizer.step()
-
-        return loss
+        return r_loss/labels.size(0)

--- a/utils/arg_parser.py
+++ b/utils/arg_parser.py
@@ -43,6 +43,8 @@ def get_args():
                         help="[GVE] path to checkpoint for pretrained weights")
     parser.add_argument('--loss-lambda', type=float, default=0.01,
                         help="[GVE] weight factor for reinforce loss")
+    parser.add_argument('--train-mismatch', type=float, default=0,
+                        help="[GVE] weight factor for mismatch loss")
 
     parser.add_argument('--embedding-size', type=int , default=1000,
                         help='dimension of the word embedding')

--- a/utils/vocabulary.py
+++ b/utils/vocabulary.py
@@ -33,6 +33,21 @@ class Vocabulary():
             return self.unknown_token
         return self.idx2word[idx]
 
+    def tokens2words(self, tokens):
+        sentences = []
+        if tokens.dim() == 1:
+            tokens = tokens.unsqueeze(0)
+        for out_idx in range(len(tokens)):
+            sentence = []
+            for w in tokens[out_idx]:
+                word = self.get_word_from_idx(w.data.item())
+                if word != self.end_token:
+                    sentence.append(word)
+                else:
+                    break
+            sentences.append(' '.join(sentence))
+        return sentences
+
     def __call__(self, word):
         if not word in self.word2idx:
             return self.word2idx[self.unknown_token]


### PR DESCRIPTION
trains GVE with a negative loss on the incorrect feature-label pairs (mismatched features taken from the same batch)

uses only one mismatch per datapoint so its not a complete mismatch training but we should see improved discrimination of attributes in generated sentences (hopefully)

we can control the influence of the new loss using --train-mismatch (defaults to 0; trains without this loss)